### PR TITLE
Improve the path to our dashboard

### DIFF
--- a/serverless.yml
+++ b/serverless.yml
@@ -49,7 +49,7 @@ functions:
     handler: handler.dashboard
     events:
       - http:
-          path: lti/dashboard
+          path: dashboard
           method: post
           integration: lambda-proxy
 


### PR DESCRIPTION
We're going to alias the gateway to lti.iliosproject.org so we don't
need the path to be /lti/dashboard just /dashboard will be fine.