### PR TITLE
Update lockfile when packages get updated

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,10 @@ cache:
 before_install:
   - if [[ `npm -v` != 5* ]]; then npm install -g npm@5; fi
   - npm -v
+  - npm install -g greenkeeper-lockfile@1
+
+before_script: greenkeeper-lockfile-update
+after_script: greenkeeper-lockfile-upload
 
 after_success:
   - test $TRAVIS_PULL_REQUEST == "false" && test $TRAVIS_BRANCH == "master" && node_modules/.bin/serverless deploy --stage=dev  --verbose


### PR DESCRIPTION
When greenkeeper automatically updates our packages, it needs to update the
lock file as well.