### PR TITLE
Remove the installation of NPM 5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,10 +7,6 @@ cache:
     - $HOME/.npm
     - $HOME/.cache
 
-before_install:
-  - if [[ `npm -v` != 5* ]]; then npm install -g npm@5; fi
-  - npm -v
-
 after_success:
   - test $TRAVIS_PULL_REQUEST == "false" && test $TRAVIS_BRANCH == "master" && node_modules/.bin/serverless deploy --stage=dev  --verbose
   - test $TRAVIS_TAG && node_modules/.bin/serverless deploy --stage=prod --verbose


### PR DESCRIPTION
NPM is at 6 now, though I think 5 still ships with Node 8. In either
case we don't need to check for this anymore.