### PR TITLE
Fix the course manager path

### DIFF
--- a/serverless.yml
+++ b/serverless.yml
@@ -60,7 +60,7 @@ functions:
     handler: handler.courseManager
     events:
       - http:
-          path: courseManager
+          path: course-manager
           method: post
           integration: lambda-proxy
   payload:


### PR DESCRIPTION
This shouldn't be camel cased, we don't use that in URLs anywhere else.
Dasherizing it makes more sense.