### PR TITLE
Provide an option school support email

### DIFF
--- a/lib/createJWT.js
+++ b/lib/createJWT.js
@@ -5,9 +5,9 @@ const PREPEND_KEY = 'ilios.jwt.key.';
 const TOKEN_ISS = 'ilios-lti-server';
 const TOKEN_AUD = 'ilios-lti-app';
 
-const createJWT = (userId, apiHost, apiNameSpace, secret) => {
+const createJWT = (userId, apiHost, apiNameSpace, supportEmailAddress, secret) => {
   const fullSecret = PREPEND_KEY + secret;
-  const token = jwt.sign({user_id: userId, apiHost, apiNameSpace}, fullSecret, {
+  const token = jwt.sign({user_id: userId, apiHost, apiNameSpace, supportEmailAddress}, fullSecret, {
     algorithm: 'HS256',
     expiresIn: '60 seconds',
     issuer: TOKEN_ISS,

--- a/lib/readSchoolConfig.js
+++ b/lib/readSchoolConfig.js
@@ -12,9 +12,14 @@ const readSchoolConfig = async(key, aws) => {
   const obj = JSON.parse(data.Body);
   if (!(key in obj)) {
     throw new Error(`The Consumer Key "${key}" is not known to Ilios. Please contact support@iliosproject.org to set it up.`);
-  } else {
-    return obj[key];
   }
+
+  const config = obj[key];
+  if (!('supportEmailAddress' in config)) {
+    config.supportEmailAddress = 'support@iliosproject.org';
+  }
+
+  return config;
 };
 
 module.exports = readSchoolConfig;

--- a/test/createJWTTest.js
+++ b/test/createJWTTest.js
@@ -9,8 +9,9 @@ describe('Generates a JWT from provided data', function() {
   const userId = 24;
   const apiHost = 'https://example.com';
   const apiNameSpace = '/api/v1';
+  const supportEmailAddress = 'support@iliosproject.org';
   const secret = 'secret';
-  const token = createJWT(userId, apiHost, apiNameSpace, secret);
+  const token = createJWT(userId, apiHost, apiNameSpace, supportEmailAddress, secret);
 
   assert.ok(token.length > 200);
   const obj = jwt.decode(token);
@@ -27,6 +28,7 @@ describe('Generates a JWT from provided data', function() {
     assert.strictEqual(obj.user_id, userId);
     assert.strictEqual(obj.apiHost, apiHost);
     assert.strictEqual(obj.apiNameSpace, apiNameSpace);
+    assert.strictEqual(obj.supportEmailAddress, supportEmailAddress);
   });
   it('expires in less than 60 seconds', function() {
     const expiresAt = moment(obj.exp, 'X');

--- a/test/readSchoolConfigTest.js
+++ b/test/readSchoolConfigTest.js
@@ -34,6 +34,7 @@ describe('Read the configuration for a school', function() {
     assert.strictEqual(result.ltiPostField, 'ext_user_username', 'ltiPostField is correct');
     assert.ok('iliosMatchField' in result, 'result contains iliosMatchField');
     assert.strictEqual(result.iliosMatchField, 'authentication-username', 'iliosMatchField is correct');
+    assert.strictEqual(result.supportEmailAddress, 'support@example.com', 'support email is correct');
   });
   it('reads the second school correctly', async function() {
     const result = await readSchoolConfig('second-school-config', aws);
@@ -51,6 +52,7 @@ describe('Read the configuration for a school', function() {
     assert.strictEqual(result.ltiPostField, 'ext_user_username', 'ltiPostField is correct');
     assert.ok('iliosMatchField' in result, 'result contains iliosMatchField');
     assert.strictEqual(result.iliosMatchField, 'authentication-username', 'iliosMatchField is correct');
+    assert.strictEqual(result.supportEmailAddress, 'support@iliosproject.org', 'sends default support email if there is not one');
   });
   it('dies well when a bad config is requested', async function() {
     try {

--- a/test/sample-config.json
+++ b/test/sample-config.json
@@ -6,7 +6,8 @@
     "consumerSecret": "secret123",
     "iliosSecret": "secret123",
     "ltiPostField": "ext_user_username",
-    "iliosMatchField": "authentication-username"
+    "iliosMatchField": "authentication-username",
+    "supportEmailAddress": "support@example.com"
   },
   "second-school-config": {
     "apiServer": "https://second-test-ilios.com",


### PR DESCRIPTION
This allows us to configure and send a school provided email address for
authentication support. If one is not provided it will send the ilios
support address which is the current default.

Refs: https://github.com/ilios/lti-dashboard/issues/380