### PR TITLE
chore: update Node.js to 14.x

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [12.x]
+        node-version: [14.x]
 
     steps:
     - uses: actions/checkout@v1

--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -10,10 +10,10 @@ jobs:
     name: Run Tests
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v1
-      - uses: actions/setup-node@v1
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v3
         with:
-          node-version: 12
+          node-version: 14
       - run: npm ci
       - run: npm test
 
@@ -22,11 +22,11 @@ jobs:
     needs: test
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v1
-    - name: Use Node.js 12
-      uses: actions/setup-node@v1
+    - uses: actions/checkout@v2
+    - name: Use Node.js 14
+      uses: actions/setup-node@v3
       with:
-        node-version: 12
+        node-version: 14
     - name: install dependencies
       run: npm ci
     - name: Serverless Deploy

--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -10,10 +10,10 @@ jobs:
     name: Run Tests
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v1
-      - uses: actions/setup-node@v1
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v3
         with:
-          node-version: 12
+          node-version: 14
       - run: npm ci
       - run: npm test
 
@@ -22,11 +22,11 @@ jobs:
     needs: test
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v1
-    - name: Use Node.js 12
-      uses: actions/setup-node@v1
+    - uses: actions/checkout@v2
+    - name: Use Node.js 14
+      uses: actions/setup-node@v3
       with:
-        node-version: 12
+        node-version: 14
     - name: install dependencies
       run: npm ci
     - name: Serverless Deploy

--- a/.github/workflows/update-transitive-dependenies.yaml
+++ b/.github/workflows/update-transitive-dependenies.yaml
@@ -11,9 +11,9 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
-    - uses: actions/setup-node@v1
+    - uses: actions/setup-node@v3
       with:
-        node-version: 12
+        node-version: 14
     - name: remove and re-create lock file
       run: |
         rm package-lock.json

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "serverless-plugin-additional-stacks": "^1.4.0"
   },
   "engines": {
-    "node": "12"
+    "node": "14"
   },
   "dependencies": {
     "aws-sdk": "^2.1095.0",


### PR DESCRIPTION
Node.js 12 is EOL at the end of April 2022. Update to Node.js 14 which
is the latest version that is supported by AWS.