### PR TITLE
Add concurrency limit for deployment runs

### DIFF
--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -5,6 +5,8 @@ on:
     branches:
       - master
 
+concurrency: deploy-dev
+
 jobs:
   test:
     name: Run Tests

--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -5,6 +5,8 @@ on:
     tags:
       - '*'
 
+concurrency: deploy-production
+
 jobs:
   test:
     name: Run Tests


### PR DESCRIPTION
This ensures that we don't try and deploy while already deploying.
Any new deployments that are triggered will stack as pending and any
pending deployments will cancel so only the last one runs.