### PR TITLE
Add Workflows to Tag and Release

### DIFF
--- a/.github/workflows/create_release.yaml
+++ b/.github/workflows/create_release.yaml
@@ -1,0 +1,39 @@
+name: Release Notes
+
+on: 
+  push:
+    tags:
+    - '*'
+
+jobs:
+  notes:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+      with:
+        fetch-depth: 0
+    - name: Get Previous Tag
+      id: previousTag
+      run: |
+        PREVIOUS_TAG=$(git describe --abbrev=0 --tags $(git rev-list --tags --skip=1 --max-count=1))
+        echo ${PREVIOUS_TAG}
+        echo ::set-output name=tag::${PREVIOUS_TAG}
+    - name: Get New Tag
+      id: nextTag
+      run: |
+        NEW_TAG=${GITHUB_REF#refs/tags/}
+        echo ${NEW_TAG}
+        echo ::set-output name=tag::${NEW_TAG}
+    - uses: actions/setup-node@v3
+    - name: Generate Release Notes
+      id: notes
+      run: |
+        NOTES=$(npx generate-github-release-notes ilios lti-server ${{ steps.previousTag.outputs.tag }} ${{steps.nextTag.outputs.tag}})
+        echo ${NOTES}
+        # remove line breaks from notes so they can be passed around
+        NOTES="${NOTES//$'\n'/'%0A'}"
+        echo "::set-output name=releaseNotes::$NOTES"
+    - uses: ncipollo/release-action@v1
+      with:
+        body: ${{steps.notes.outputs.releaseNotes}}
+        token: ${{ secrets.ZORGBORT_TOKEN }}

--- a/.github/workflows/tag_version.yaml
+++ b/.github/workflows/tag_version.yaml
@@ -1,0 +1,26 @@
+name: Tag Version
+
+on:
+  workflow_dispatch:
+    inputs:
+      releaseType:
+        description: 'Semver Release Type (major,minor,patch)'
+        required: true
+
+jobs:
+  tag:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+      with:
+          token: ${{ secrets.ZORGBORT_TOKEN }}
+    - name: Validate releaseType
+      run: npx in-string-list ${{ github.event.inputs.releaseType }} major,minor,patch
+    - name: Setup Git
+      run: |
+        git config user.name Zorgbort
+        git config user.email info@iliosproject.org
+    - name: Increment Version
+      run: npm version ${{ github.event.inputs.releaseType }}
+    - name: Push Changes
+      run: git push --follow-tags


### PR DESCRIPTION
This allows us to easily tag and action with a workflow dispatch event
and respond to newly created tags by adding release notes.