### PR TITLE
bump version on automerge action.

### DIFF
--- a/.github/workflows/automerge.yml
+++ b/.github/workflows/automerge.yml
@@ -23,7 +23,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: automerge
-        uses: "pascalgn/automerge-action@v0.8.4"
+        uses: "pascalgn/automerge-action@v0.16.2"
         env:
           GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
           MERGE_REMOVE_LABELS: "automerge"


### PR DESCRIPTION
the old version stopped working, see  https://github.com/ilios/lti-server/actions/runs/8110169079/job/22166853719?pr=1655 for an example.

i hope upgrading will set things right again.