### PR TITLE
Skip Installing Dev Dependencies for Deployment

### DIFF
--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -35,7 +35,7 @@ jobs:
       with:
         node-version: 20
     - name: install dependencies
-      run: pnpm install
+      run: pnpm install --prod
     - name: Serverless Deploy
       run: pnpm run deploy:dev
       env:

--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -35,7 +35,7 @@ jobs:
       with:
         node-version: 20
     - name: install dependencies
-      run: pnpm install
+      run: pnpm install --prod
     - name: Serverless Deploy
       run: pnpm run deploy:production
       env:


### PR DESCRIPTION
This should significantly reduce our bundle size, we'll have to test and ensure the application still functions correctly after it is deployed.