### PR TITLE
Remove aws-sdk from Deploy

### DIFF
--- a/serverless.yml
+++ b/serverless.yml
@@ -78,3 +78,8 @@ resources:
       Type: "AWS::SDB::Domain"
       Properties:
         Description: LaunchLTI SimpleDB for caching userId values
+
+package:
+  patterns:
+    - "!node_modules/aws-sdk/**"
+    - "!node_modules/**/aws-sdk/**"


### PR DESCRIPTION
Attempting to lower our bundle size and this library is included by lambda automatically so we can remove it from our upload and hopefully save a bunch of space.