### PR TITLE
Update Dependency Management

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,8 +3,11 @@ updates:
 - package-ecosystem: npm
   directory: "/"
   schedule:
-    interval: daily
-    time: "02:30"
-    timezone: America/Los_Angeles
+    interval: weekly
   open-pull-requests-limit: 10
   versioning-strategy: increase
+
+- package-ecosystem: github-actions
+  directory: /
+  schedule:
+    interval: weekly

--- a/.github/workflows/automerge.yml
+++ b/.github/workflows/automerge.yml
@@ -1,32 +1,21 @@
-name: Auto Merge Labeled Pull Requests
-
-on:
-  pull_request:
-    types:
-      - labeled
-      - unlabeled
-      - synchronize
-      - opened
-      - edited
-      - ready_for_review
-      - reopened
-      - unlocked
-  pull_request_review:
-    types:
-      - submitted
-  check_suite:
-    types:
-      - completed
-  status: {}
+name: Dependabot auto-merge
+on: pull_request_target
+permissions:
+  pull-requests: write
+  contents: write
 jobs:
-  automerge:
+  dependabot:
     runs-on: ubuntu-latest
+    if: ${{ github.actor == 'dependabot[bot]' }}
     steps:
-      - name: automerge
-        uses: "pascalgn/automerge-action@v0.16.2"
+      - name: Dependabot metadata
+        id: metadata
+        uses: dependabot/fetch-metadata@v2
+        with:
+          github-token: "${{ secrets.GITHUB_TOKEN }}"
+      - uses: actions/checkout@v4
+      - name: Enable auto-merge for Dependabot PRs
+        if: ${{(steps.metadata.outputs.update-type == 'version-update:semver-minor' || steps.metadata.outputs.update-type == 'version-update:semver-patch') }}
+        run: gh pr merge --merge --auto ${{ github.event.number }}
         env:
-          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
-          MERGE_REMOVE_LABELS: "automerge"
-          MERGE_FILTER_AUTHOR: "zorgbort"
-          MERGE_FORKS: "false"
-          MERGE_DELETE_BRANCH: "true"
+          GH_TOKEN: ${{ secrets.ZORGBORT_TOKEN }}

--- a/.github/workflows/update-transitive-dependencies.yaml
+++ b/.github/workflows/update-transitive-dependencies.yaml
@@ -2,29 +2,29 @@ name: Update Transitive Dependencies
 
 on:
   schedule:
-    - cron: '15 11 * * 6' # weekly, on Saturday morning (UTC)
+    - cron: "15 11 * * 6" # weekly, on Saturday morning (UTC)
+  workflow_dispatch: null
 
 jobs:
   update:
-    name: Tests
     runs-on: macos-latest
-
     steps:
-    - uses: actions/checkout@v4
-    - uses: pnpm/action-setup@v4
-      with:
-        version: 9
-    - uses: actions/setup-node@v4
-      with:
-        node-version: 20
-    - name: remove and re-create lock file
-      run: |
-        rm pnpm-lock.yaml
-        pnpm install --fix-lockfile
-        pnpm dedupe
-    - name: Create Pull Request
-      uses: peter-evans/create-pull-request@v3
-      with:
+      - uses: actions/checkout@v4
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 9
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+      - name: remove and re-create lock file
+        run: |
+          rm pnpm-lock.yaml
+          pnpm install --fix-lockfile
+          pnpm dedupe
+      - name: Create Pull Request
+        id: cpr
+        uses: peter-evans/create-pull-request@v6
+        with:
           token: ${{ secrets.ZORGBORT_TOKEN }}
           commit-message: Update Transitive Dependencies
           title: Update Transitive Dependencies
@@ -35,4 +35,9 @@ jobs:
 
             [1]: https://github.com/peter-evans/create-pull-request
           branch: auto-update-dependencies
-          labels: dependencies,automerge
+          labels: dependencies
+      - name: Enable Pull Request Automerge
+        if: steps.cpr.outputs.pull-request-operation == 'created'
+        run: gh pr merge --merge --auto ${{ steps.cpr.outputs.pull-request-number }}
+        env:
+          GH_TOKEN: ${{ secrets.ZORGBORT_TOKEN }}


### PR DESCRIPTION
I've aligned this with our other less frequently modified apps:
- Dependabot will run weekly and update github actions as well
- Auto merge will happen for any PRs that are minor or patch updates
- Our weekly full lockfile update will automerge