### PR TITLE
Package and Store the Serverless Deployment

### DIFF
--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -36,8 +36,15 @@ jobs:
         node-version: 20
     - name: install dependencies
       run: pnpm install --prod
-    - name: Serverless Deploy
-      run: pnpm run deploy:dev
+    - run: pnpm exec serverless package --stage dev
+    - uses: actions/upload-artifact@v4
+      with:
+        name: dev-ilios-lti-launch.zip
+        path: ./.serverless/ilios-lti-launch.zip
+        if-no-files-found: error
+        retention-days: 3
+        compression-level: 0
+    - run: pnpm exec serverless deploy --stage dev --package ./.serverless/ilios-lti-launch.zip --conceal
       env:
         AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
         AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}


### PR DESCRIPTION
Storing this artifact so we can check it out later, then using that created file as the upload. I also found and added a "conceal" option with is probably a good idea in CI as it will hide sensitive stuff in the output.