### PR TITLE
Remove Package Hack

### DIFF
--- a/serverless.yml
+++ b/serverless.yml
@@ -78,8 +78,3 @@ resources:
       Type: "AWS::SDB::Domain"
       Properties:
         Description: LaunchLTI SimpleDB for caching userId values
-
-package:
-  patterns:
-    - "!node_modules/aws-sdk/**"
-    - "!node_modules/**/aws-sdk/**"


### PR DESCRIPTION
Serverless v4 seems to do a better job of packaging out app and I don't think we need this anymore.