### PR TITLE
Move aws-sdk to dev dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
   "license": "MIT",
   "devDependencies": {
     "@stylistic/eslint-plugin-js": "^2.3.0",
+    "aws-sdk": "^2.1659.0",
     "eslint": "^9.7.0",
     "eslint-plugin-mocha": "^10.4.3",
     "eslint-plugin-n": "^17.2.1",
@@ -31,7 +32,6 @@
     "npm": "use pnpm"
   },
   "dependencies": {
-    "aws-sdk": "^2.1659.0",
     "jsonwebtoken": "^9.0.2",
     "meow": "^11.0.0",
     "node-fetch": "^3.3.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,9 +8,6 @@ importers:
 
   .:
     dependencies:
-      aws-sdk:
-        specifier: ^2.1659.0
-        version: 2.1659.0
       jsonwebtoken:
         specifier: ^9.0.2
         version: 9.0.2
@@ -30,6 +27,9 @@ importers:
       '@stylistic/eslint-plugin-js':
         specifier: ^2.3.0
         version: 2.3.0(eslint@9.7.0)
+      aws-sdk:
+        specifier: ^2.1659.0
+        version: 2.1659.0
       eslint:
         specifier: ^9.7.0
         version: 9.7.0
@@ -627,9 +627,6 @@ packages:
 
   ieee754@1.1.13:
     resolution: {integrity: sha512-4vf7I2LYV/HaWerSo3XmlMkp5eZ83i+/CDluXi/IGTs/O1sejBNhTtnxzmRZfvOUqj7lZjqHkeTvpgSFDlWZTg==}
-
-  ieee754@1.2.1:
-    resolution: {integrity: sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==}
 
   ignore@5.3.1:
     resolution: {integrity: sha512-5Fytz/IraMjqpwfd34ke28PTVMjZjJG2MPn5t7OE4eUCUNf8BAa7b5WUS9/Qvr6mwOQS7Mk6vdsMno5he+T8Xw==}
@@ -1441,7 +1438,7 @@ snapshots:
   buffer@4.9.2:
     dependencies:
       base64-js: 1.5.1
-      ieee754: 1.2.1
+      ieee754: 1.1.13
       isarray: 1.0.0
 
   call-bind@1.0.7:
@@ -1853,8 +1850,6 @@ snapshots:
       lru-cache: 7.18.3
 
   ieee754@1.1.13: {}
-
-  ieee754@1.2.1: {}
 
   ignore@5.3.1: {}
 


### PR DESCRIPTION
This is provided for us by AWS, we don't need it to get deployed.