### PR TITLE
Install Dependencies Correctly for AWS Lambda

### DIFF
--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -38,8 +38,8 @@ jobs:
     - uses: actions/setup-node@v4
       with:
         node-version: 20
-    - name: install dependencies
-      run: pnpm install
+    - name: install dependencies hoisted for lambda
+      run: pnpm install --node-linker=hoisted
     - run: pnpm exec serverless package --stage dev
     - uses: actions/upload-artifact@v4
       with:

--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -38,8 +38,8 @@ jobs:
     - uses: actions/setup-node@v4
       with:
         node-version: 20
-    - name: install dependencies
-      run: pnpm install
+    - name: install dependencies hoisted for lambda
+      run: pnpm install --node-linker=hoisted
     - name: Serverless Deploy
       run: pnpm run deploy:production
     - uses: act10ns/slack@v2


### PR DESCRIPTION
Lambda doesn't do well with the symlink structure that pnpm creates, instead we need to use this config option on install to create a more traditional node_modules structure.

This issue is specifically documented at https://pnpm.io/next/npmrc#node-linker
and [here](https://github.com/pnpm/pnpm.io/blob/85e23b18c3936d6f0986bc5ed87582e167003403/versioned_docs/version-8.x/npmrc.md?plain=1#L158) is a link to the source for those docs which may be more helpful at some future time.