### PR TITLE
Fix Tagging Workflow

### DIFF
--- a/.github/workflows/tag_version.yaml
+++ b/.github/workflows/tag_version.yaml
@@ -26,7 +26,7 @@ jobs:
       - name: Increment Version
         run: npx versionup --level ${{ github.event.inputs.releaseType }}
       - run: |
-          NEW_TAG=`node -p "require('package.json').version"`
+          NEW_TAG=`node -p "require('./package.json').version"`
           echo ${NEW_TAG}
           echo "new_tag=${NEW_TAG}" >> $GITHUB_ENV
       - name: Tag Version


### PR DESCRIPTION
Needed the directory leader otherwise node tries to lookup a global module with this name.