### PR TITLE
Send Prompt with Login Redirect

### DIFF
--- a/app.ts
+++ b/app.ts
@@ -157,6 +157,9 @@ export const loginHandler = async (event: APIGatewayProxyEvent): Promise<APIGate
   params.scope = 'openid';
   params.redirect_uri = target_link_uri;
   params.response_mode = 'form_post';
+  params.prompt = 'none';
+
+  console.log('Params: ' + JSON.stringify(params));
 
   const qp = querystring.encode(params);
 


### PR DESCRIPTION
This appears to be required, at least by canvas. It is labeled as optional in the OpenID spec, but we get an error from canvas if we don't send it. None is the recommended value.