### PR TITLE
Support Looking up Users by Campus ID

### DIFF
--- a/bin/lookup.ts
+++ b/bin/lookup.ts
@@ -13,9 +13,10 @@ program
   .argument('<apiNameSpace>', 'API namespace')
   .argument('<iliosSecret>', 'Ilios secret')
   .argument('<searchString>', 'Search string')
+  .option('--match-field <match field>', 'Field to match on', 'authentication-username')
   .action(
     async (ltiUserId: string, apiServer: string, apiNameSpace: string, iliosSecret: string, searchString: string) => {
-      const iliosMatchField = 'authentication-username';
+      const iliosMatchField: string = program.opts().matchField;
       const config: Lti11SchoolConfig = {
         ltiUserId: Number(ltiUserId),
         apiServer,

--- a/lib/findIliosUser.ts
+++ b/lib/findIliosUser.ts
@@ -4,26 +4,51 @@ import { SchoolConfig } from './readSchoolConfig';
 export type FindIliosUser = (config: SchoolConfig, searchString: string, createJWT: CreateJWT) => Promise<number>;
 
 export default async (config: SchoolConfig, searchString: string, createJWT: CreateJWT): Promise<number> => {
-  let url = config.apiServer + config.apiNameSpace;
-  switch (config.iliosMatchField) {
-    case 'authentication-username':
-      url += `/authentications?filters[username]=${searchString}`;
-      break;
+  if (config.iliosMatchField === 'authentication-username') {
+    return fetchByUsername(config, createJWT, searchString);
   }
+
+  if (config.iliosMatchField === 'user-campusid') {
+    return fetchByCampusId(config, createJWT, searchString);
+  }
+
+  throw new Error(`Unknown iliosMatchField "${config.iliosMatchField}" in school config.`);
+};
+
+async function fetchByUsername(config: SchoolConfig, createJWT: CreateJWT, username: string): Promise<number> {
+  const url = `${config.apiServer}${config.apiNameSpace}/authentications?filters[username]=${username}`;
   const adminToken = createJWT(config.ltiUserId, config.apiServer, config.apiNameSpace, config.iliosSecret);
-  console.log(`Searching for user ${searchString} at ${url} with token ${adminToken}`);
+  console.log(`Searching for user at ${url} with token ${adminToken}`);
   const data = await fetch(url, {
     headers: {
       'X-JWT-Authorization': `Token ${adminToken}`,
     },
   });
   const result = await data.json();
-
   if ('authentications' in result && result.authentications.length > 0) {
     const userId = result.authentications[0].user;
     console.log(`User ${userId} found`);
     return userId;
   } else {
-    throw new Error(`Unable to find Ilios account for ${searchString}.`);
+    throw new Error(`Unable to find Ilios account for username "${username}".`);
   }
-};
+}
+
+async function fetchByCampusId(config: SchoolConfig, createJWT: CreateJWT, campusId: string): Promise<number> {
+  const url = `${config.apiServer}${config.apiNameSpace}/users?filters[campusId]=${campusId}`;
+  const adminToken = createJWT(config.ltiUserId, config.apiServer, config.apiNameSpace, config.iliosSecret);
+  console.log(`Searching for user at ${url} with token ${adminToken}`);
+  const data = await fetch(url, {
+    headers: {
+      'X-JWT-Authorization': `Token ${adminToken}`,
+    },
+  });
+  const result = await data.json();
+  if ('users' in result && result.users.length > 0) {
+    const userId = result.users[0].id;
+    console.log(`User ${userId} found`);
+    return userId;
+  } else {
+    throw new Error(`Unable to find Ilios account for campusId "${campusId}".`);
+  }
+}

--- a/tests/unit/test-find-ilios-user.test.ts
+++ b/tests/unit/test-find-ilios-user.test.ts
@@ -15,16 +15,6 @@ describe('Get the ID for a user', function () {
     fetchMock.disableMocks();
   });
 
-  const config: Lti11SchoolConfig = {
-    consumerSecret: 'school-name',
-    apiServer: 'https://test-ilios.com',
-    apiNameSpace: '/test/api/v3',
-    ltiUserId: 33,
-    iliosSecret: 'secret123',
-    ltiPostField: 'ext_user_username',
-    iliosMatchField: 'authentication-username',
-    ltiVersion: 1.1,
-  };
   const searchString = 'test-username';
   const createJWT: CreateJWT = (id: number) => `TOKEN${id}`;
 
@@ -34,6 +24,17 @@ describe('Get the ID for a user', function () {
         authentications: [{ user: 24, username: searchString }],
       }),
     );
+
+    const config: Lti11SchoolConfig = {
+      consumerSecret: 'school-name',
+      apiServer: 'https://test-ilios.com',
+      apiNameSpace: '/test/api/v3',
+      ltiUserId: 33,
+      iliosSecret: 'secret123',
+      ltiPostField: 'ext_user_username',
+      iliosMatchField: 'authentication-username',
+      ltiVersion: 1.1,
+    };
 
     const result = await findIliosUser(config, searchString, createJWT);
     expect(result).toEqual(24);
@@ -49,12 +50,50 @@ describe('Get the ID for a user', function () {
         authentications: [],
       }),
     );
+
+    const config: Lti11SchoolConfig = {
+      consumerSecret: 'school-name',
+      apiServer: 'https://test-ilios.com',
+      apiNameSpace: '/test/api/v3',
+      ltiUserId: 33,
+      iliosSecret: 'secret123',
+      ltiPostField: 'ext_user_username',
+      iliosMatchField: 'authentication-username',
+      ltiVersion: 1.1,
+    };
+
     expect(async () => {
       await findIliosUser(config, searchString, createJWT);
-    }).rejects.toThrow(`Unable to find Ilios account for ${searchString}.`);
+    }).rejects.toThrow(`Unable to find Ilios account for username "${searchString}".`);
     expect(fetchMock.mock.calls.length).toEqual(1);
     expect(fetchMock.mock.calls[0][0]).toEqual(
       `${config.apiServer}${config.apiNameSpace}/authentications?filters[username]=${searchString}`,
+    );
+  });
+
+  it('calls the api and returns a userId for campusId', async function () {
+    fetchMock.mockResponseOnce(
+      JSON.stringify({
+        users: [{ id: 24, campusId: searchString }],
+      }),
+    );
+
+    const config: Lti11SchoolConfig = {
+      consumerSecret: 'school-name',
+      apiServer: 'https://test-ilios.com',
+      apiNameSpace: '/test/api/v3',
+      ltiUserId: 33,
+      iliosSecret: 'secret123',
+      ltiPostField: 'ext_user_username',
+      iliosMatchField: 'user-campusid',
+      ltiVersion: 1.1,
+    };
+
+    const result = await findIliosUser(config, searchString, createJWT);
+    expect(result).toEqual(24);
+    expect(fetchMock.mock.calls.length).toEqual(1);
+    expect(fetchMock.mock.calls[0][0]).toEqual(
+      `${config.apiServer}${config.apiNameSpace}/users?filters[campusId]=${searchString}`,
     );
   });
 });


### PR DESCRIPTION
Depending on authentication configuration in the LMS it may be easier to get access to a shared campus ID than a eppn or other shared login.