### PR TITLE
Support Custom LTI ilios_user Attribute

### DIFF
--- a/lib/validateAndExtractLTI13JWT.ts
+++ b/lib/validateAndExtractLTI13JWT.ts
@@ -55,6 +55,16 @@ export default async (request: Lti13Event, schoolConfig: Lti13SchoolConfig): Pro
         }
         break;
       }
+      case 'custom_ilios_user': {
+        const custom = payload[`${IMS}/custom`] as Record<string, string>;
+        if (Object.keys(custom).includes('ilios_user')) {
+          iliosSearchId = custom.ilios_user;
+        } else {
+          console.info(custom);
+          throw new Error('custom ilios_user missing from payload');
+        }
+        break;
+      }
       default:
         console.info(schoolConfig, payload);
         throw new Error(`Undefined ${schoolConfig.ltiPostField} requested.`);


### PR DESCRIPTION
If the userId isn't readily available in one of the standard attributes the LMS can be configured to send custom values. I standardized on ilios_user and the LMS can send anything it wants for that.