### PR TITLE
Add Service Token Options

### DIFF
--- a/app.ts
+++ b/app.ts
@@ -8,6 +8,7 @@ import ltiRequestValidator from './lib/ltiRequestValidator';
 import readSchoolConfig from './lib/readSchoolConfig';
 import findIliosUser from './lib/findIliosUser';
 import createJWT from './lib/createJWT';
+import requestJWT from './lib/requestJWT';
 import { generateAndStore, validate } from './lib/manageStateAndNonce';
 import validateAndExtractLTI13JWT from './lib/validateAndExtractLTI13JWT';
 
@@ -41,6 +42,7 @@ export const dashboardHandler = async (event: APIGatewayProxyEvent): Promise<API
           readSchoolConfig,
           findIliosUser,
           createJWT,
+          requestJWT,
           validate,
         );
       case 1.1:

--- a/bin/cli.ts
+++ b/bin/cli.ts
@@ -1,4 +1,5 @@
-import createJWT from '../lib/createJWT';
+import { ServiceTokenConfig } from '../lib/readSchoolConfig';
+import requestJWT from '../lib/requestJWT';
 import { Command } from 'commander';
 
 const program = new Command();
@@ -8,12 +9,18 @@ program
   .description('Generate an LTI login URL with a JWT token')
   .argument('<ltiAppUrl>', 'LTI application URL')
   .argument('<apiServer>', 'API server URL')
-  .argument('<apiNameSpace>', 'API namespace')
-  .argument('<iliosSecret>', 'Ilios secret')
+  .argument('<serviceToken>', 'Service Token')
   .argument('<userId>', 'User ID')
-  .action((ltiAppUrl: string, apiServer: string, apiNameSpace: string, iliosSecret: string, userId: string) => {
-    const token = createJWT(Number(userId), apiServer, apiNameSpace, iliosSecret);
-    const targetUrl = `${ltiAppUrl}/login/${token}`;
+  .action(async (ltiAppUrl: string, apiServer: string, serviceToken: string, userId: string) => {
+    const config: ServiceTokenConfig = {
+      apiServer,
+      serviceToken,
+      apiNameSpace: '',
+      iliosMatchField: '',
+      ltiPostField: '',
+    };
+    const token = await requestJWT(Number(userId), config);
+    const targetUrl = `${ltiAppUrl}/lti-login/${token}`;
     process.stdout.write(targetUrl + '\n');
   });
 

--- a/lib/findIliosUser.ts
+++ b/lib/findIliosUser.ts
@@ -17,7 +17,10 @@ export default async (config: SchoolConfig, searchString: string, createJWT: Cre
 
 async function fetchByUsername(config: SchoolConfig, createJWT: CreateJWT, username: string): Promise<number> {
   const url = `${config.apiServer}${config.apiNameSpace}/authentications?filters[username]=${username}`;
-  const adminToken = createJWT(config.ltiUserId, config.apiServer, config.apiNameSpace, config.iliosSecret);
+  const adminToken =
+    'serviceToken' in config
+      ? config.serviceToken
+      : createJWT(config.ltiUserId, config.apiServer, config.apiNameSpace, config.iliosSecret);
   console.log(`Searching for user at ${url} with token ${adminToken}`);
   const data = await fetch(url, {
     headers: {
@@ -36,7 +39,10 @@ async function fetchByUsername(config: SchoolConfig, createJWT: CreateJWT, usern
 
 async function fetchByCampusId(config: SchoolConfig, createJWT: CreateJWT, campusId: string): Promise<number> {
   const url = `${config.apiServer}${config.apiNameSpace}/users?filters[campusId]=${campusId}`;
-  const adminToken = createJWT(config.ltiUserId, config.apiServer, config.apiNameSpace, config.iliosSecret);
+  const adminToken =
+    'serviceToken' in config
+      ? config.serviceToken
+      : createJWT(config.ltiUserId, config.apiServer, config.apiNameSpace, config.iliosSecret);
   console.log(`Searching for user at ${url} with token ${adminToken}`);
   const data = await fetch(url, {
     headers: {

--- a/lib/launchDashboard.ts
+++ b/lib/launchDashboard.ts
@@ -9,6 +9,7 @@ import { CreateJWT } from './createJWT';
 import { ValidateAndExtractLTI13JWT } from './validateAndExtractLTI13JWT';
 import { Validate } from './manageStateAndNonce';
 import { DynamoDBClient } from '@aws-sdk/client-dynamodb';
+import { RequestJWT } from './requestJWT';
 
 export const launchDashboardV11 = async (
   request: Lti11Event,
@@ -67,6 +68,7 @@ export const launchDashboardV13 = async (
   readSchoolConfig: ReadSchoolConfig,
   findIliosUser: FindIliosUser,
   createJWT: CreateJWT,
+  requestJWT: RequestJWT,
   validate: Validate,
 ): Promise<APIGatewayProxyResult> => {
   if (!process.env.DASHBOARD_APP_URL) {
@@ -91,13 +93,23 @@ export const launchDashboardV13 = async (
     const userId = await findIliosUser(config, payload.iliosSearchId, createJWT);
     if (userId) {
       console.log(`Found user ${userId}.`);
-      const token = createJWT(userId, config.apiServer, config.apiNameSpace, config.iliosSecret);
-
-      if (!process.env.DASHBOARD_APP_URL) {
-        throw new Error('DASHBOARD_APP_URL is not defined, nowhere to redirect authenticated user');
+      let token: string;
+      let targetUrl: string;
+      if ('serviceToken' in config) {
+        console.log(`Requesting token for ${userId} using service token ${config.serviceToken.substring(0, 15)}.`);
+        token = await requestJWT(userId, config);
+        const apiServer = config.apiServer.endsWith('/') ? config.apiServer : `${config.apiServer}/`;
+        targetUrl = `${apiServer}/lti-login/${token}`;
+        console.log(`Retrieved token for ${userId}.`);
+      } else {
+        if (!process.env.DASHBOARD_APP_URL) {
+          throw new Error('DASHBOARD_APP_URL is not defined, nowhere to redirect authenticated user');
+        }
+        token = createJWT(userId, config.apiServer, config.apiNameSpace, config.iliosSecret);
+        targetUrl = `${process.env.DASHBOARD_APP_URL}/login/${token}`;
+        console.log(`Generated token for ${userId}.`);
       }
 
-      const targetUrl = `${process.env.DASHBOARD_APP_URL}/login/${token}`;
       const response = {
         statusCode: 302,
         headers: {

--- a/lib/readSchoolConfig.ts
+++ b/lib/readSchoolConfig.ts
@@ -4,16 +4,24 @@ interface BaseConfig {
   apiServer: string;
   apiNameSpace: string;
   iliosMatchField: string;
-  ltiUserId: number;
-  iliosSecret: string;
   ltiPostField: string;
 }
 
-export interface Lti11SchoolConfig extends BaseConfig {
+interface SecretConfig extends BaseConfig {
+  ltiUserId: number;
+  iliosSecret: string;
+}
+
+export interface ServiceTokenConfig extends BaseConfig {
+  serviceToken: string;
+}
+
+export interface Lti11SchoolConfig extends SecretConfig {
   ltiVersion: 1.1;
   consumerSecret: string;
 }
-export interface Lti13SchoolConfig extends BaseConfig {
+
+export interface Lti13Config extends BaseConfig {
   ltiVersion: 1.3;
   keysetUrl: string;
   authenticationRequestUrl: string;
@@ -21,7 +29,10 @@ export interface Lti13SchoolConfig extends BaseConfig {
   clientId: string;
 }
 
-export type SchoolConfig = Lti11SchoolConfig | Lti13SchoolConfig;
+export interface Lti13SchoolConfig extends SecretConfig, Lti13Config {}
+export interface Lti13ServiceTokenSchoolConfig extends ServiceTokenConfig, Lti13Config {}
+
+export type SchoolConfig = Lti11SchoolConfig | Lti13SchoolConfig | Lti13ServiceTokenSchoolConfig;
 
 export type ReadSchoolConfig = (key: string, s3Client: S3Client) => Promise<SchoolConfig>;
 

--- a/lib/requestJWT.ts
+++ b/lib/requestJWT.ts
@@ -1,0 +1,29 @@
+import { ServiceTokenConfig } from './readSchoolConfig';
+
+export type RequestJWT = (userId: number, config: ServiceTokenConfig) => Promise<string>;
+
+export default async (userId: number, config: ServiceTokenConfig): Promise<string> => {
+  const apiServer = config.apiServer.endsWith('/') ? config.apiServer : `${config.apiServer}/`;
+  const url = `${apiServer}auth/token/${userId}`;
+  const data = await fetch(url, {
+    headers: {
+      'X-JWT-Authorization': `Token ${config.serviceToken}`,
+    },
+  });
+  if (!data.ok) {
+    throw new Error(`Unable to request token for user: ${data.statusText}`);
+  }
+  const body = await data.text();
+  try {
+    const result = JSON.parse(body);
+
+    if ('jwt' in result) {
+      return result.jwt;
+    }
+
+    throw new Error('JWT not in response');
+  } catch (e) {
+    const message = e instanceof Error ? e.message : 'no more info';
+    throw new Error(`Unable to parse token JSON (${message}) from ${url}. Body: ${body}`);
+  }
+};

--- a/lib/validateAndExtractLTI13JWT.ts
+++ b/lib/validateAndExtractLTI13JWT.ts
@@ -1,17 +1,17 @@
 import { Lti13Event } from './eventToRequest';
 import { jwtVerify, createRemoteJWKSet } from 'jose';
-import { Lti13SchoolConfig } from './readSchoolConfig';
+import { Lti13Config } from './readSchoolConfig';
 
 export interface Lti13Data {
   iliosSearchId: string;
   email: string;
 }
 
-export type ValidateAndExtractLTI13JWT = (request: Lti13Event, schoolConfig: Lti13SchoolConfig) => Promise<Lti13Data>;
+export type ValidateAndExtractLTI13JWT = (request: Lti13Event, schoolConfig: Lti13Config) => Promise<Lti13Data>;
 
 const IMS = 'https://purl.imsglobal.org/spec/lti/claim';
 
-export default async (request: Lti13Event, schoolConfig: Lti13SchoolConfig): Promise<Lti13Data> => {
+export default async (request: Lti13Event, schoolConfig: Lti13Config): Promise<Lti13Data> => {
   try {
     console.log('Validating and extracting LTI Payload', schoolConfig, request);
     // Create a Remote JSON Web Key Set (JWK Set) using the Moodle certs URL

--- a/tests/unit/test-request-jwt.test.ts
+++ b/tests/unit/test-request-jwt.test.ts
@@ -1,0 +1,83 @@
+import requestJWT from '../../lib/requestJWT';
+import { expect, describe, it } from '@jest/globals';
+import fetchMock from 'jest-fetch-mock';
+import { ServiceTokenConfig } from '../../lib/readSchoolConfig';
+
+describe('Requests new token from API', function () {
+  const config: ServiceTokenConfig = {
+    apiServer: 'https://example.com/',
+    apiNameSpace: '',
+    serviceToken: 'abc',
+    iliosMatchField: '',
+    ltiPostField: '',
+  };
+  beforeAll(function () {
+    fetchMock.enableMocks();
+  });
+  beforeEach(function () {
+    fetchMock.resetMocks();
+  });
+  afterAll(function () {
+    fetchMock.disableMocks();
+  });
+
+  it('calls the API and extracts a token', async function () {
+    fetchMock.mockResponseOnce(
+      JSON.stringify({
+        jwt: '123',
+      }),
+    );
+
+    const result = await requestJWT(123, config);
+    expect(result).toEqual('123');
+    expect(fetchMock.mock.calls.length).toEqual(1);
+    expect(fetchMock.mock.calls[0][0]).toEqual(`${config.apiServer}auth/token/123`);
+  });
+
+  it('fails when request fails', async function () {
+    fetchMock.mockResponseOnce('', { status: 401 });
+    await expect(async () => {
+      await requestJWT(123, config);
+    }).rejects.toThrow(`Unable to request token for user: Unauthorized`);
+    expect(fetchMock.mock.calls.length).toEqual(1);
+    expect(fetchMock.mock.calls[0][0]).toEqual(`${config.apiServer}auth/token/123`);
+  });
+
+  it('fails with bad data', async function () {
+    fetchMock.mockResponseOnce(
+      JSON.stringify({
+        nothing: '123',
+      }),
+    );
+    await expect(async () => {
+      await requestJWT(123, config);
+    }).rejects.toThrow(/^Unable to parse token JSON \(JWT not in response/);
+    expect(fetchMock.mock.calls.length).toEqual(1);
+    expect(fetchMock.mock.calls[0][0]).toEqual(`${config.apiServer}auth/token/123`);
+  });
+
+  it('fails with bad json', async function () {
+    fetchMock.mockResponseOnce('<html></html>');
+    await expect(async () => {
+      await requestJWT(123, config);
+    }).rejects.toThrow(/^Unable to parse token JSON \(Unexpected token/);
+    expect(fetchMock.mock.calls.length).toEqual(1);
+    expect(fetchMock.mock.calls[0][0]).toEqual(`${config.apiServer}auth/token/123`);
+  });
+
+  it('Adds trailing slash to apiServer', async function () {
+    fetchMock.mockResponseOnce(
+      JSON.stringify({
+        jwt: '123',
+      }),
+    );
+
+    const result = await requestJWT(123, {
+      ...config,
+      apiServer: 'https://example.edu',
+    });
+    expect(result).toEqual('123');
+    expect(fetchMock.mock.calls.length).toEqual(1);
+    expect(fetchMock.mock.calls[0][0]).toEqual(`https://example.edu/auth/token/123`);
+  });
+});


### PR DESCRIPTION
Fetch user token, fetch user details, and redirect the user using our new service token and single frontend solution. Punting on some tests and cleanup for now because we're going to phase out every other way of working with the LTI and remove most of this code very soon.